### PR TITLE
Matplotlib regression testing

### DIFF
--- a/PlotFuncs.py
+++ b/PlotFuncs.py
@@ -1,5 +1,7 @@
 import matplotlib
-matplotlib.use('MacOSX')
+import platform
+if platform.system() == 'Darwin':
+    matplotlib.use('MacOSX')
 import matplotlib.pyplot as plt
 plt.style.use('./allcrs.mplstyle')
 import numpy as np
@@ -126,7 +128,7 @@ class TheCrSpectrum():
         ax.text(0.9e3, 3e-5, r'$\gamma$ IGRB', fontsize=20)
         #ax.text(0.6e3, 4e2, r'$\sim E^{-2.7}$')
         #ax.text(5.5e8, 1e-2, r'$\sim E^{-3.1}$')
-        ax.text(1.1e12, 2e-1, 'github.com/carmeloevoli/The\_CR\_Spectrum', rotation=-90, fontsize=10, color='tab:gray')
+        ax.text(1.1e12, 2e-1, r'github.com/carmeloevoli/The_CR_Spectrum', rotation=-90, fontsize=10, color='tab:gray')
         
     def ypos(self, i):
         f_text = 1.95

--- a/test_cr_plot.py
+++ b/test_cr_plot.py
@@ -1,0 +1,19 @@
+import pytest
+from PlotFuncs import TheCrSpectrum
+
+@pytest.mark.mpl_image_compare(tolerance=0.5, savefig_kwargs={'dpi':300})
+def test_allparticle_plot():
+    
+    plot = TheCrSpectrum()
+    fig, ax = plot.FigSetup()
+    plot.positrons(ax)
+    plot.leptons(ax)
+    plot.protons(ax)
+    plot.antiprotons(ax)
+    plot.allparticle(ax)
+    plot.gammas(ax)
+    plot.neutrinos(ax)
+    plot.experiment_legend(ax)
+    plot.annotate(ax)
+    
+    return fig


### PR DESCRIPTION
[This](https://github.com/matplotlib/pytest-mpl) is the library I was mentioning before!
Usage:

```bash
pip install pytest pytest-mpl
pytest --mpl-generate-path=baseline # generate baseline image in the folder "baseline"
pytest --mpl # should succeed
```

Then, if you change something (even a single datapoint, although there is a small tolerance in the test) you should get a failure, and you can get an image showing the difference visually with

```bash 
pytest --mpl --mpl-results-path=results # save the difference image in the folder "results"
```

Example, changing a neutrino flux:

### Baseline
![baseline](https://user-images.githubusercontent.com/11020774/223138260-5721b8a5-2f91-4a96-9249-573283ebe233.png)

### Result
![result](https://user-images.githubusercontent.com/11020774/223138289-9bb217f3-a1b3-44e1-85ec-e709b32e006d.png)

### Diff
![result-failed-diff](https://user-images.githubusercontent.com/11020774/223138299-b3a2549d-0e73-4e19-b72b-5f5cb0dd63db.png)

Also, I made the `matplotlib.use('MacOSX')` conditional on the code actually being run on a Mac 
(it was failing otherwise on my system); and swapped the escaped underscores in the link for a raw string literal (since they are currently [being deprecated](https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals)).